### PR TITLE
trigger the done callback after the response has ended.

### DIFF
--- a/tasks/shopify.js
+++ b/tasks/shopify.js
@@ -234,9 +234,9 @@ module.exports = function(grunt) {
 
                 res.on('end', function () {
                     shopify.notify(res, "uploading file on shopify");
+                    return done(true);
                 });
 
-                return done(true);
             });
 
             req.on('error', function(e) {


### PR DESCRIPTION
The notification happens only by accident unless we wait for the response object to trigger its 'end' event.
