### PR TITLE
handful of minor tweaks.

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,6 @@
   "dependencies": {
     "async": "~0.2.9",
     "isbinaryfile": "~2.0.0",
-    "shopify-api": "~0.2.0"
+    "shopify-api": "~0.2.2"
   }
 }


### PR DESCRIPTION
just some minor things i noticed. also shopify-api should now catch `errors` and give back an error with `type` of `ShopifyInvalidRequestError` with a `detail` key containing the `errors` array. i will have some more tweaks in the next few weeks after i overhaul shopify-api based on some of the things i seen here including merging the asset so that you dont need assetLegacy or that whole if statement.
