### PR TITLE
Fixes case where  `shopify.downloadTheme` is broken on first try

### DIFF
--- a/tasks/lib/shopify.js
+++ b/tasks/lib/shopify.js
@@ -144,7 +144,7 @@ module.exports = function(grunt) {
             basePath = shopify._getBasePath(),
             destination = path.join(basePath, key);
 
-        shopify.notify('Uploading "' + key + '".');
+        shopify.notify('Downloading "' + key + '".');
 
         if (typeof obj.asset.value !== 'undefined') {
             contents = obj.asset.value;


### PR DESCRIPTION
`shopify.downloadTheme` was calling `shopify.download` with original Shopify key. Passing this through `shopify._makeAssetKey` resulted in a relative URL, e.g. "../assets/logo.png", which is an invalid key.

By joining this key with base path we retain original interface of `shopify.download`, and in turn the `shopify:download` task.
