### PR TITLE
Fix bug where customer templates wouldn't upload

### DIFF
--- a/tasks/lib/shopify.js
+++ b/tasks/lib/shopify.js
@@ -292,7 +292,8 @@ module.exports = function(grunt) {
             'config/*.*',
             'layout/*.*',
             'snippets/*.*',
-            'templates/*.*'
+            'templates/*.*',
+            'templates/customers/*.*'
         ]);
 
         async.eachSeries(filepaths, function(filepath, next) {


### PR DESCRIPTION
This was a problem when using `grunt shopify:upload` without passing a
specific file.
