### PR TITLE
Bump version number to 0.5.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-shopify",
   "description": "Grunt plug-in for publishing Shopify theme templates and assets.",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "homepage": "https://github.com/wilr/grunt-shopify",
   "author": {
     "name": "Will Rossiter",


### PR DESCRIPTION
When you `npm install` it installs 0.5.0 because this was not updated.
