### PR TITLE
Add option to deploy without settings_data.json

### DIFF
--- a/tasks/lib/shopify.js
+++ b/tasks/lib/shopify.js
@@ -284,7 +284,7 @@ module.exports = function(grunt) {
      *
      * @param {Function} done
      */
-    shopify.deploy = function(done) {
+    shopify.deploy = function(done, noJson) {
         var c = grunt.config('shopify');
 
         var basePath = shopify._getBasePath();
@@ -297,6 +297,11 @@ module.exports = function(grunt) {
             'templates/*.*',
             'templates/customers/*.*'
         ]);
+
+        if (noJson) {
+            var index = filepaths.indexOf('settings_data.json');
+            filepaths.splice(index, 1);
+        }
 
         async.eachSeries(filepaths, function(filepath, next) {
             shopify.upload(path.join(basePath, filepath), next);

--- a/tasks/shopify.js
+++ b/tasks/shopify.js
@@ -37,10 +37,11 @@ module.exports = function(grunt) {
 
     grunt.registerTask('shopify:upload', 'Uploads a single theme file to Shopify, or the entire theme if no file is specified', function(p) {
         var done = this.async();
+        var noJson = grunt.option('no-json') || false;
         if (p) {
           shopify.upload(p, done);
         } else {
-          shopify.deploy(done);
+          shopify.deploy(done, noJson);
         }
     });
 


### PR DESCRIPTION
Sometimes I just want to upload all new files without overwriting
my current settings. It's easy to hop into the theme editor in
the Shopify backend and rollback to a previous version of the
file but this makes it even easier.

Simply pass `--no-json` as an option to the `shopify:upload` task:

```
grunt shopify:upload --no-json
```
