### PR TITLE
Only act on files that are explicitly being watched

### DIFF
--- a/tasks/lib/shopify.js
+++ b/tasks/lib/shopify.js
@@ -102,6 +102,17 @@ module.exports = function(grunt) {
     };
 
     /*
+     * Determine if path is being watched.
+     *
+     * @return {Boolean}
+     */
+    shopify._isWatchedPath = function(filepath) {
+        watchedFolders = grunt.config('watch').shopify.files;
+
+        return grunt.file.isMatch(watchedFolders,filepath);
+    };
+
+    /*
      * Convert a file path on the local file system to an asset path in shopify
      * as you may run grunt at a higher directory locally.
      *
@@ -429,7 +440,7 @@ module.exports = function(grunt) {
             }
         }
 
-        if (!shopify._isPathInBase(filepath)) {
+        if (!shopify._isWatchedPath(filepath)) {
             return;
         }
 


### PR DESCRIPTION
This removes all warnings from terminal when you're working on files
that are outside of the whitelisted folders.

When working in a scripts or styles folder you'll no longer be warned
that these files cannot be uploaded.

Fixes some later comments in https://github.com/wilr/grunt-shopify/issues/16
