### PR TITLE
add queue for watched file

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,14 @@ On top of using Growl notifications for application status, error messages are
 output in via grunt log. Turning off the grunt log will keep your terminal clear
 in 
 
+#### rate_limit_delay
+
+Type: `Number`
+Default value: `500`
+
+Interval in milliseconds between the API calls when running the watch task.
+According to the [Shopify docs](https://docs.shopify.com/api/introduction/api-call-limit) the API call limit is set to 2 calls per second, so a sensitive default value like 500ms ensure that no API error will occurs.
+
 ## Contributing
 
 In lieu of a formal styleguide, take care to maintain the existing coding style. 


### PR DESCRIPTION
These changes introduce a queue mechanism (using [caolan/async queue](https://github.com/caolan/async#queue)) for processing the watched files.

Before this change all grunt watch events were considered as a requests burst from Shopify when performing some actions like checkout different local branches with a lot of theme diffs.
This caused some API errors, and some time consume while developing.
Now with the queue all changed files will be processed one by one.