### PR TITLE
Added `sections` path to whitelist, to allow for section development.

### DIFF
--- a/tasks/lib/shopify.js
+++ b/tasks/lib/shopify.js
@@ -135,7 +135,7 @@ module.exports = function(grunt) {
     shopify._isWhitelistedPath = function(filepath) {
         filepath = shopify._makePathRelative(filepath);
 
-        return filepath.match(/^(assets|config|layout|snippets|templates|locales)\//i);
+        return filepath.match(/^(assets|config|layout|snippets|sections|templates|locales)\//i);
     };
 
     /*


### PR DESCRIPTION
Currently `grunt-shopify` does not support uploading files within the `sections` folder, as it is not part of the `shopify._isWhitelistedPath` matcher. This PR updates that function to allow changes within `sections` to be uploaded.